### PR TITLE
Add product editing functionality

### DIFF
--- a/templates/edit.html
+++ b/templates/edit.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Edit Product</h2>
+<form method="post" class="card p-3">
+  <div class="mb-3">
+    <label class="form-label">Name</label>
+    <input name="name" class="form-control" value="{{ product.name }}" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">URL</label>
+    <input name="url" class="form-control" value="{{ product.url }}" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Country</label>
+    <input name="country" class="form-control" value="{{ product.country }}" required>
+  </div>
+  <button type="submit" class="btn btn-primary">Save</button>
+  <a href="{{ url_for('index') }}" class="btn btn-secondary ms-2">Cancel</a>
+</form>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -122,6 +122,7 @@
         </td>
         <td>{{ p.last_ts or '—' }}</td>
         <td>
+            <a href="{{ url_for('edit', pid=p.id) }}" class="btn btn-sm btn-outline-primary">Edit</a>
             <a href="{{ url_for('toggle', pid=p.id) }}" class="btn btn-sm btn-outline-secondary">
                 {{ 'Disable' if p.enabled else 'Enable' }}
             </a>

--- a/tests/test_edit_product.py
+++ b/tests/test_edit_product.py
@@ -1,0 +1,39 @@
+import os
+import unittest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+# disable scheduler before importing app
+os.environ["CARDWATCH_DISABLE_SCHEDULER"] = "1"
+
+import app as cardapp
+import db
+
+class EditProductTest(unittest.TestCase):
+    def setUp(self):
+        engine = create_engine('sqlite:///:memory:', future=True)
+        db.SessionLocal = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+        db.Base.metadata.create_all(engine)
+        cardapp.app.config['TESTING'] = True
+        self.client = cardapp.app.test_client()
+        s = db.SessionLocal()
+        try:
+            s.add(db.Product(id=1, name='old', url='u', country='c'))
+            s.commit()
+        finally:
+            s.close()
+
+    def test_edit_updates_record(self):
+        resp = self.client.post('/edit/1', data={'name': 'new', 'url': 'u2', 'country': 'c2'}, follow_redirects=True)
+        self.assertEqual(resp.status_code, 200)
+        s = db.SessionLocal()
+        try:
+            p = s.get(db.Product, 1)
+            self.assertEqual(p.name, 'new')
+            self.assertEqual(p.url, 'u2')
+            self.assertEqual(p.country, 'c2')
+        finally:
+            s.close()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow editing existing products via new `/edit/<id>` route and template
- show Edit action in product list
- add tests for editing and option to disable scheduler during tests

## Testing
- `PYTHONPATH=$PWD CARDWATCH_DISABLE_SCHEDULER=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af3a52b148832e9ca43f16b541761e