### PR TITLE
Add supply tracking, percent change columns, and row navigation

### DIFF
--- a/db.py
+++ b/db.py
@@ -25,6 +25,7 @@ class Price(Base):
     low = Column(Float, nullable=False)            # lowest of the scraped 5
     avg5 = Column(Float, nullable=False)           # average of the scraped 5
     n_seen = Column(Integer, nullable=False)       # how many rows parsed (<=5)
+    supply = Column(Integer, nullable=True)        # available items on site
 
     product = relationship("Product", back_populates="prices")
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -56,15 +56,18 @@
         <th data-field="current"     data-sortable="true" data-sorter="priceSorter">Current&nbsp;€</th>
         <th data-field="first"       data-sortable="true" data-sorter="priceSorter">First&nbsp;€</th>
         <th data-field="trend"       data-sortable="true">Trend</th>
+        <th data-field="pct24"       data-sortable="true" data-sorter="priceSorter">24h%</th>
+        <th data-field="pct7"        data-sortable="true" data-sorter="priceSorter">7d%</th>
+        <th data-field="pct30"       data-sortable="true" data-sorter="priceSorter">30d%</th>
+        <th data-field="supply"      data-sortable="true">Supply</th>
         <th data-field="heads"       data-sortable="true">Heads‑up</th>
         <th data-field="last_update" data-sortable="true" data-sorter="minuteDateSorter">Last update</th>
-        <th data-field="actions">Actions</th>
     </tr>
     </thead>
     <tbody>
     {% for p in products %}
-    <tr>
-        <td><a href="{{ url_for('product', pid=p.id) }}">{{ p.name }}</a></td>
+    <tr data-href="{{ url_for('product', pid=p.id) }}">
+        <td>{{ p.name }}</td>
         <td>
             {% if p.country == "Germany" %}
             <span class="fi fi-de" title="Germany"></span>
@@ -110,6 +113,22 @@
 
         <td class="trend {{ p.trend }}">{{ p.trend }}</td>
         <td>
+            {% if p.pct24 is not none %}
+            {{ '%.2f'|format(p.pct24) }}%
+            {% else %}—{% endif %}
+        </td>
+        <td>
+            {% if p.pct7 is not none %}
+            {{ '%.2f'|format(p.pct7) }}%
+            {% else %}—{% endif %}
+        </td>
+        <td>
+            {% if p.pct30 is not none %}
+            {{ '%.2f'|format(p.pct30) }}%
+            {% else %}—{% endif %}
+        </td>
+        <td>{{ p.supply if p.supply is not none else '—' }}</td>
+        <td>
             {% if p.heads %}
             <span class="badge bg-warning text-dark">
     LOW NOW: €{{ '%.2f'|format(p.current_low) }}
@@ -121,17 +140,6 @@
 
         </td>
         <td>{{ p.last_ts or '—' }}</td>
-        <td>
-            <a href="{{ url_for('edit', pid=p.id) }}" class="btn btn-sm btn-outline-primary">Edit</a>
-            <a href="{{ url_for('toggle', pid=p.id) }}" class="btn btn-sm btn-outline-secondary">
-                {{ 'Disable' if p.enabled else 'Enable' }}
-            </a>
-            <form action="{{ url_for('delete', pid=p.id) }}" method="post" class="d-inline">
-                <button class="btn btn-sm btn-outline-danger" onclick="return confirm('Delete?')">
-                    Delete
-                </button>
-            </form>
-        </td>
     </tr>
     {% endfor %}
     </tbody>
@@ -170,6 +178,11 @@
     // Activate bootstrap-table once DOM and scripts are ready
     $(function () {
         $('#mainTable').bootstrapTable();
+        $('#mainTable tbody').on('click', 'tr', function (e) {
+            if ($(e.target).closest('a, button').length) return;
+            const href = $(this).data('href');
+            if (href) window.location = href;
+        });
     });
 
     // Country dropdown handler (if you use the custom dropdown)

--- a/templates/product.html
+++ b/templates/product.html
@@ -1,7 +1,19 @@
 {% extends "base.html" %}
 {% block content %}
 <h2>{{ product.name }}</h2>
-<p><a href="{{ product.url }}" target="_blank" rel="noopener">Open listing</a> • Country filter: {{ product.country }}</p>
+<p>
+    <a href="{{ product.url }}" target="_blank" rel="noopener">Open listing</a>
+    • Country filter: {{ product.country }}
+</p>
+<div class="mb-3">
+    <a href="{{ url_for('edit', pid=product.id) }}" class="btn btn-sm btn-outline-primary">Edit</a>
+    <a href="{{ url_for('toggle', pid=product.id) }}" class="btn btn-sm btn-outline-secondary">
+        {{ 'Disable' if product.is_enabled else 'Enable' }}
+    </a>
+    <form action="{{ url_for('delete', pid=product.id) }}" method="post" class="d-inline">
+        <button class="btn btn-sm btn-outline-danger" onclick="return confirm('Delete?')">Delete</button>
+    </form>
+</div>
 
 <canvas id="hchart"></canvas>
 <canvas id="dchart" style="margin-top:24px;"></canvas>

--- a/tests/test_parse_supply.py
+++ b/tests/test_parse_supply.py
@@ -1,0 +1,16 @@
+import pytest
+
+from scraper import parse_supply
+
+
+def test_parse_supply_basic():
+    html = '''<div class="info">
+    <dt class="col-6">Available items</dt>
+    <dd class="col-6">42</dd>
+    </div>'''
+    assert parse_supply(html) == 42
+
+
+def test_parse_supply_not_found_returns_none():
+    html = '<div>nothing here</div>'
+    assert parse_supply(html) is None


### PR DESCRIPTION
## Summary
- Make table rows clickable and move product actions to detail page
- Track available item supply during scraping and store in database
- Display 24h, 7d, 30d percent change and supply columns on index
- Parse supply from DOM `Available items` definition list for reliable scraping
- Add unit test for supply parsing

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af3e4a88c8832e92ca4c4750b3fa8f