### PR TITLE
Colorize percentage change columns

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -114,17 +114,20 @@
         <td class="trend {{ p.trend }}">{{ p.trend }}</td>
         <td>
             {% if p.pct24 is not none %}
-            {{ '%.2f'|format(p.pct24) }}%
+            {% set cls = 'text-success' if p.pct24 > 0 else ('text-danger' if p.pct24 < 0 else 'text-muted') %}
+            <span class="{{ cls }}">{{ '%.2f'|format(p.pct24) }}%</span>
             {% else %}—{% endif %}
         </td>
         <td>
             {% if p.pct7 is not none %}
-            {{ '%.2f'|format(p.pct7) }}%
+            {% set cls = 'text-success' if p.pct7 > 0 else ('text-danger' if p.pct7 < 0 else 'text-muted') %}
+            <span class="{{ cls }}">{{ '%.2f'|format(p.pct7) }}%</span>
             {% else %}—{% endif %}
         </td>
         <td>
             {% if p.pct30 is not none %}
-            {{ '%.2f'|format(p.pct30) }}%
+            {% set cls = 'text-success' if p.pct30 > 0 else ('text-danger' if p.pct30 < 0 else 'text-muted') %}
+            <span class="{{ cls }}">{{ '%.2f'|format(p.pct30) }}%</span>
             {% else %}—{% endif %}
         </td>
         <td>{{ p.supply if p.supply is not none else '—' }}</td>


### PR DESCRIPTION
## Summary
- Display 24h, 7d, and 30d percent changes in green for gains and red for losses

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af4b88ce24832eafe226ea77fff554