### PR TITLE
Refine Edit Product form layout

### DIFF
--- a/templates/edit.html
+++ b/templates/edit.html
@@ -1,20 +1,24 @@
 {% extends "base.html" %}
 {% block content %}
 <h2>Edit Product</h2>
-<form method="post" class="card p-3">
-  <div class="mb-3">
-    <label class="form-label">Name</label>
-    <input name="name" class="form-control" value="{{ product.name }}" required>
+<form method="post" class="card shadow-sm mx-auto" style="max-width: 480px;">
+  <div class="card-body">
+    <div class="mb-3">
+      <label class="form-label">Name</label>
+      <input name="name" class="form-control" value="{{ product.name }}" required>
+    </div>
+    <div class="mb-3">
+      <label class="form-label">URL</label>
+      <input name="url" class="form-control" value="{{ product.url }}" required>
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Country</label>
+      <input name="country" class="form-control" value="{{ product.country }}" required>
+    </div>
+    <div class="d-flex">
+      <button type="submit" class="btn btn-primary">Save</button>
+      <a href="{{ url_for('index') }}" class="btn btn-secondary ms-2">Cancel</a>
+    </div>
   </div>
-  <div class="mb-3">
-    <label class="form-label">URL</label>
-    <input name="url" class="form-control" value="{{ product.url }}" required>
-  </div>
-  <div class="mb-3">
-    <label class="form-label">Country</label>
-    <input name="country" class="form-control" value="{{ product.country }}" required>
-  </div>
-  <button type="submit" class="btn btn-primary">Save</button>
-  <a href="{{ url_for('index') }}" class="btn btn-secondary ms-2">Cancel</a>
 </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Center edit form with card styling and constrained width
- Arrange Save and Cancel buttons horizontally

## Testing
- `python -m pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68af4cf54f08832ea629cd6d97523172