### PR TITLE
Add landing page linking to CardWatch and Tracker

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,6 +17,12 @@ if not os.environ.get("CARDWATCH_DISABLE_SCHEDULER") and (
     scheduler = schedule_hourly()
 
 @app.route("/")
+def home():
+    return render_template("home.html")
+
+
+@app.route("/cardwatch")
+@app.route("/cardwatch/")
 def index():
     s = get_session()
     try:
@@ -80,7 +86,7 @@ def index():
     finally:
         s.close()
 
-@app.route("/product/<int:pid>")
+@app.route("/cardwatch/product/<int:pid>")
 def product(pid):
     s = get_session()
     try:
@@ -92,7 +98,7 @@ def product(pid):
         s.close()
 
 
-@app.route("/api/product/<int:pid>/series")
+@app.route("/cardwatch/api/product/<int:pid>/series")
 def api_series(pid):
     s = get_session()
     try:
@@ -101,7 +107,7 @@ def api_series(pid):
     finally:
         s.close()
 
-@app.route("/api/product/<int:pid>/daily")
+@app.route("/cardwatch/api/product/<int:pid>/daily")
 def api_daily(pid):
     s = get_session()
     try:
@@ -110,7 +116,7 @@ def api_daily(pid):
     finally:
         s.close()
 
-@app.route("/add", methods=["POST"])
+@app.route("/cardwatch/add", methods=["POST"])
 def add():
     name = request.form.get("name", "").strip()
     url = request.form.get("url", "").strip()
@@ -138,7 +144,7 @@ def add():
             print(f"[app] Error scraping new product {pid}: {e}")
     return redirect(url_for("index"))
 
-@app.route("/edit/<int:pid>", methods=["GET", "POST"])
+@app.route("/cardwatch/edit/<int:pid>", methods=["GET", "POST"])
 def edit(pid):
     s = get_session()
     try:
@@ -166,7 +172,7 @@ def edit(pid):
     finally:
         s.close()
 
-@app.route("/toggle/<int:pid>")
+@app.route("/cardwatch/toggle/<int:pid>")
 def toggle(pid):
     s = get_session()
     try:
@@ -178,7 +184,7 @@ def toggle(pid):
     finally:
         s.close()
 
-@app.route("/delete/<int:pid>", methods=["POST"])
+@app.route("/cardwatch/delete/<int:pid>", methods=["POST"])
 def delete(pid):
     s = get_session()
     try:

--- a/templates/base.html
+++ b/templates/base.html
@@ -46,7 +46,7 @@
 <!-- Navbar -->
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
     <div class="container">
-        <a class="navbar-brand fw-semibold" href="{{ url_for('index') }}">CardWatch</a>
+        <a class="navbar-brand fw-semibold" href="{{ url_for('home') }}">CardWatch</a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbars"
                 aria-controls="navbars" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
@@ -55,7 +55,10 @@
             <ul class="navbar-nav ms-auto">
                 <!-- Add more nav links if needed -->
                 <li class="nav-item">
-                    <a class="nav-link" href="{{ url_for('index') }}">Home</a>
+                    <a class="nav-link" href="{{ url_for('index') }}">CardWatch</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="/tracker/">Tracker</a>
                 </li>
             </ul>
         </div>

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="text-center">
+    <h1>Select an application</h1>
+    <a class="btn btn-primary m-2" href="{{ url_for('index') }}">CardWatch</a>
+    <a class="btn btn-secondary m-2" href="/tracker/">Tracker</a>
+</div>
+{% endblock %}

--- a/tests/test_edit_product.py
+++ b/tests/test_edit_product.py
@@ -24,7 +24,7 @@ class EditProductTest(unittest.TestCase):
             s.close()
 
     def test_edit_updates_record(self):
-        resp = self.client.post('/edit/1', data={'name': 'new', 'url': 'u2', 'country': 'c2'}, follow_redirects=True)
+        resp = self.client.post('/cardwatch/edit/1', data={'name': 'new', 'url': 'u2', 'country': 'c2'}, follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
         s = db.SessionLocal()
         try:


### PR DESCRIPTION
## Summary
- Add root landing page with links to CardWatch and the new Tracker app
- Move CardWatch routes under `/cardwatch` and update navbar
- Adjust tests for new route structure

## Testing
- `CARDWATCH_DISABLE_SCHEDULER=1 PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1781c22e4832ea0e0f29270c5270d