### PR TITLE
Reduce table font size in lists

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -2,7 +2,7 @@ body { font-family: system-ui, sans-serif; margin: 0; }
 nav { background:#111; color:#fff; padding:10px 16px; display:flex; gap:12px; align-items:center; }
 nav a { color:#ddd; text-decoration:none; }
 main { padding: 16px; }
-table.list { width:100%; border-collapse: collapse; }
+table.list { width:100%; border-collapse: collapse; font-size: 0.9em; }
 table.list th, table.list td { padding: 8px; border-bottom: 1px solid #eee; }
 .badge.warn { padding: 4px 6px; border-radius: 6px; background: #ffe8e6; border:1px solid #ffb3ab; }
 .trend.up { color: #0a7a0a; }


### PR DESCRIPTION
## Summary
- shrink font size within list tables for a more compact view

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b19e21dfc8832ebc70117e8a9e1d21