### PR TITLE
Cache pricecharting data in background

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,7 +5,7 @@ import asyncio
 from flask import Flask, render_template, request, redirect, url_for, jsonify, flash
 from db import init_db, get_session, Product, Price, Daily
 from scraper import schedule_hourly, compute_trend, is_heads_up, scrape_once
-from tracker_flask import tracker_bp
+from tracker_flask import tracker_bp, init_tracker_scheduler
 from datetime import datetime, timedelta
 
 app = Flask(__name__)
@@ -18,6 +18,7 @@ if not os.environ.get("CARDWATCH_DISABLE_SCHEDULER") and (
     scheduler = schedule_hourly()
 
 app.register_blueprint(tracker_bp)
+tracker_scheduler = init_tracker_scheduler()
 
 @app.route("/")
 def home():

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,2 @@
+import os, sys
+sys.path.append(os.path.dirname(__file__))

--- a/templates/tracker/item_list.html
+++ b/templates/tracker/item_list.html
@@ -123,3 +123,21 @@
 
     </div>
 {% endblock %}
+
+{% block extra_scripts %}
+<script>
+let cacheTs = "{{ cache_ts or '' }}";
+async function checkTrackerUpdates() {
+    try {
+        const resp = await fetch("{{ url_for('tracker.api_cache_ts') }}");
+        const data = await resp.json();
+        if (data.ts && data.ts !== cacheTs) {
+            location.reload();
+        }
+    } catch (err) {
+        console.error('update check failed', err);
+    }
+}
+setInterval(checkTrackerUpdates, 60000);
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Refresh tracker pricecharting data on a background schedule and expose update timestamp API
- Reload tracker view when cache changes and avoid blocking page loads
- Start tracker scheduler from the Flask app and add test helper to ensure module import

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b19f14517c832ebcc7147797307954