### PR TITLE
Fix chart loading and bootstrap script integrity issues

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -27,20 +27,7 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     {% block extra_head %}{% endblock %}
 </head>
-<script src="https://code.jquery.com/jquery-3.7.1.min.js"
-        integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo="
-        crossorigin="anonymous"></script>
 
-<!-- Bootstrap JS bundle (correct SRI for 5.3.3) -->
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
-        integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
-        crossorigin="anonymous"></script>
-
-<!-- bootstrap-table (depends on jQuery; should come AFTER jQuery) -->
-<script src="https://unpkg.com/bootstrap-table@1.22.1/dist/bootstrap-table.min.js"></script>
-
-<!-- Chart.js (unchanged) -->
-<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <body class="bg-light">
 
 <!-- Navbar -->
@@ -82,11 +69,14 @@
     {% block content %}{% endblock %}
 </main>
 
-<!-- Bootstrap JS Bundle (with Popper) -->
-<script
-        src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
-        integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+76nVd4IoEv8sP1FQmY5nlt9gZx9n"
+<!-- JavaScript dependencies -->
+<script src="https://code.jquery.com/jquery-3.7.1.min.js"
+        integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo="
         crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
+        crossorigin="anonymous"></script>
+<script src="https://unpkg.com/bootstrap-table@1.22.1/dist/bootstrap-table.min.js"></script>
 
 {% block extra_scripts %}{% endblock %}
 

--- a/templates/product.html
+++ b/templates/product.html
@@ -20,8 +20,8 @@
 
 <script>
     async function draw(){
-        const hourly = await (await fetch(`/api/product/{{product.id}}/series`)).json();
-        const daily  = await (await fetch(`/api/product/{{product.id}}/daily`)).json();
+        const hourly = await (await fetch("{{ url_for('api_series', pid=product.id) }}")).json();
+        const daily  = await (await fetch("{{ url_for('api_daily', pid=product.id) }}")).json();
 
         const ht = hourly.map(p => p.t);
         const hlow = hourly.map(p => p.low);


### PR DESCRIPTION
## Summary
- correct API fetch paths in product view to include `/cardwatch`
- tidy base template to load JavaScript dependencies once with correct SRI hashes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1a12e44f8832e98c2c827e4a0d00e