### PR TITLE
Add ability to delete tracker items

### DIFF
--- a/templates/tracker/item_form.html
+++ b/templates/tracker/item_form.html
@@ -48,4 +48,9 @@
     <button class="btn btn-primary" type="submit">Save</button>
     <a href="{{ url_for('tracker.item_list') }}" class="btn btn-secondary">Back</a>
 </form>
+{% if item %}
+<form action="{{ url_for('tracker.item_delete', item_id=item.id) }}" method="post" class="mt-2">
+    <button class="btn btn-danger" type="submit">Delete</button>
+</form>
+{% endif %}
 {% endblock %}

--- a/tests/test_tracker_delete.py
+++ b/tests/test_tracker_delete.py
@@ -1,0 +1,63 @@
+import os
+from datetime import date
+
+from flask import Flask
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+import db
+import tracker_flask
+
+
+os.environ["CARDWATCH_DISABLE_SCHEDULER"] = "1"
+
+
+def create_app():
+    engine = create_engine("sqlite:///:memory:", future=True)
+    db.SessionLocal = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+    db.Base.metadata.create_all(engine)
+
+    app = Flask(__name__, template_folder="../templates")
+    app.secret_key = "test"
+    app.register_blueprint(tracker_flask.tracker_bp)
+    app.add_url_rule("/", "home", lambda: "")
+    app.add_url_rule("/cardwatch", "index", lambda: "")
+    return app
+
+
+def test_delete_removes_item_and_shows_in_edit():
+    app = create_app()
+    client = app.test_client()
+
+    session = db.SessionLocal()
+    try:
+        item = db.Item(
+            name="DeleteMe",
+            buy_date=date.today(),
+            graded=0,
+            price=1.0,
+            currency="USD",
+        )
+        session.add(item)
+        session.commit()
+        item_id = item.id
+    finally:
+        session.close()
+
+    resp = client.get("/tracker/")
+    assert resp.status_code == 200
+    assert f"/tracker/delete/{item_id}" not in resp.get_data(as_text=True)
+
+    resp = client.get(f"/tracker/edit/{item_id}")
+    assert resp.status_code == 200
+    assert f"/tracker/delete/{item_id}" in resp.get_data(as_text=True)
+
+    resp = client.post(f"/tracker/delete/{item_id}", follow_redirects=True)
+    assert resp.status_code == 200
+
+    session = db.SessionLocal()
+    try:
+        assert session.get(db.Item, item_id) is None
+    finally:
+        session.close()
+


### PR DESCRIPTION
## Summary
- allow tracker entries to be removed
- add delete button to item edit panel and expose delete route
- cover deletion path and ensure list view stays non-destructive

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c139f01950832eaf893a532a2984e2